### PR TITLE
Native pflog data-link type, typo fixes and single-instance checking

### DIFF
--- a/softflowd.8
+++ b/softflowd.8
@@ -116,7 +116,7 @@ and
 that the accounting datagrams are to be sent to.
 The host may be specified using a hostname or using a numeric IPv4 or
 IPv6 address.
-Numeric IPv6 addresses should be encosed in square brackets to avoid ambiguity
+Numeric IPv6 addresses should be enclosed in square brackets to avoid ambiguity
 between the address and the port.
 The destination port may be a portname listed in
 .Xr services 5

--- a/softflowd.c
+++ b/softflowd.c
@@ -1951,6 +1951,19 @@ main(int argc, char **argv)
 		r = daemon(0, 0);
 		loginit(PROGNAME, 0);
 
+		if ((pidfile = fopen(pidfile_path, "r")) != NULL) {
+			int pid;
+			fscanf(pidfile,"%d", &pid);
+			fclose(pidfile);
+			
+			/* Check if the pid exists */
+			int pidfree = (kill(pid, 0) && errno == ESRCH);
+			if (!pidfree) {
+				fprintf(stderr, "Already running under pid %d\n",
+					pid);
+				exit(1);
+			}
+                }
 		if ((pidfile = fopen(pidfile_path, "w")) == NULL) {
 			fprintf(stderr, "Couldn't open pidfile %s: %s\n",
 			    pidfile_path, strerror(errno));

--- a/softflowd.c
+++ b/softflowd.c
@@ -1953,13 +1953,13 @@ main(int argc, char **argv)
 
 		if ((pidfile = fopen(pidfile_path, "r")) != NULL) {
 			int pid;
-			fscanf(pidfile,"%d", &pid);
+			fscanf(pidfile,"%u", &pid);
 			fclose(pidfile);
 			
 			/* Check if the pid exists */
 			int pidfree = (kill(pid, 0) && errno == ESRCH);
 			if (!pidfree) {
-				fprintf(stderr, "Already running under pid %d\n",
+				fprintf(stderr, "Already running under pid %u\n",
 					pid);
 				exit(1);
 			}

--- a/softflowd.c
+++ b/softflowd.c
@@ -90,6 +90,9 @@ static const struct DATALINK lt[] = {
 #ifdef DLT_LOOP
 	{ DLT_LOOP,	 4,  0,  4,  1, 0xffffffff, AF_INET, AF_INET6 },
 #endif
+#ifdef DLT_PFLOG
+        { DLT_PFLOG,    48,  1,  1,  0, 0x000000ff, AF_INET, AF_INET6 },
+#endif
 	{ -1,		-1, -1, -1, -1, 0x00000000,  0xffff,   0xffff },
 };
 
@@ -1297,7 +1300,7 @@ accept_control(int lsock, struct NETFLOW_TARGET *target, struct FLOWTRACK *ft,
 		print_timeouts(ft, ctlf);
 		ret = 0;
 	} else {
-		fprintf(ctlf, "Unknown control commmand \"%s\"\n", buf);
+		fprintf(ctlf, "Unknown control command \"%s\"\n", buf);
 		ret = 0;
 	}
 


### PR DESCRIPTION
- Implemented the "DLT_PFLOG" data-link type (as per the patch found in the FreeBSD port of softflowd)
- Fixed a few typos (as they were fixed in Ubuntu softflowd 0.9.9-3 package)
- Implemented single-instance checking using the pid file (see commit 2f195a0 comment for discussion)