### PR TITLE
Add autoconf tools to build instructions in README

### DIFF
--- a/README
+++ b/README
@@ -33,6 +33,8 @@ Installing
 
 Building softflowd should be as simple as typing:
 
+autoconf
+autoreconf
 ./configure
 make
 make install


### PR DESCRIPTION
The build instructions were misleading as the configure script is not
inclueded in the files shipped with repository.

Maybe I'm missing something, but I had to look it up to be able to build softflowd.