### PR TITLE
Replace deprecated bzero with memset

### DIFF
--- a/freelist.c
+++ b/freelist.c
@@ -46,7 +46,7 @@ freelist_init(struct freelist *fl, size_t allocsz)
 {
 	size_t sizeof_fl = sizeof(fl);
 	FLOGIT((LOG_DEBUG, "%s: %s(%p, %zu)", __func__, __func__, fl, allocsz));
-	bzero(fl, sizeof_fl);
+	memset(fl, 0, sizeof_fl);
 	fl->allocsz = roundup(allocsz, FREELIST_ALLOC_ALIGN);
 	fl->free_entries = NULL;
 }

--- a/ipfix.c
+++ b/ipfix.c
@@ -388,7 +388,7 @@ ipfix_init_template_unity (struct FLOWTRACKPARAMETERS *param,
                            u_int8_t icmp_flag, u_int8_t bi_flag,
                            u_int16_t version) {
   u_int index = 0, bi_index = 0, length = 0;
-  bzero (template, sizeof (*template));
+  memset (template, 0, sizeof (*template));
   template->h.c.set_id = htons (version == 10 ?
                                 IPFIX_TEMPLATE_SET_ID :
                                 NFLOW9_TEMPLATE_SET_ID);
@@ -510,7 +510,7 @@ nflow9_init_option (u_int16_t ifidx, struct OPTION *option) {
     NFLOW9_SOFTFLOWD_OPTION_TEMPLATE_NRECORDS *
     sizeof (struct IPFIX_FIELD_SPECIFIER);
 
-  bzero (&option_template, sizeof (option_template));
+  memset (&option_template, 0, sizeof (option_template));
   option_template.h.c.set_id = htons (NFLOW9_OPTION_TEMPLATE_SET_ID);
   option_template.h.c.length =
     htons (sizeof (option_template.h) + scope_len + opt_len);
@@ -524,7 +524,7 @@ nflow9_init_option (u_int16_t ifidx, struct OPTION *option) {
   ipfix_init_fields (option_template.r, &option_index,
                      field_nf9option,
                      NFLOW9_SOFTFLOWD_OPTION_TEMPLATE_NRECORDS);
-  bzero (&nf9opt_data, sizeof (nf9opt_data));
+  memset (&nf9opt_data, 0, sizeof (nf9opt_data));
   nf9opt_data.c.set_id = htons (IPFIX_SOFTFLOWD_OPTION_TEMPLATE_ID);
   nf9opt_data.c.length = htons (sizeof (nf9opt_data));
   nf9opt_data.scope_ifidx = htonl (ifidx);
@@ -536,7 +536,7 @@ nflow9_init_option (u_int16_t ifidx, struct OPTION *option) {
 static void
 ipfix_init_option (struct timeval *system_boot_time, struct OPTION *option) {
   u_int scope_index = 0, option_index = 0;
-  bzero (&option_template, sizeof (option_template));
+  memset (&option_template, 0, sizeof (option_template));
   option_template.h.c.set_id = htons (IPFIX_OPTION_TEMPLATE_SET_ID);
   option_template.h.c.length = htons (sizeof (option_template));
   option_template.h.u.i.r.template_id =
@@ -553,7 +553,7 @@ ipfix_init_option (struct timeval *system_boot_time, struct OPTION *option) {
   ipfix_init_fields (option_template.r, &option_index, field_option,
                      IPFIX_SOFTFLOWD_OPTION_TEMPLATE_NRECORDS);
 
-  bzero (&option_data, sizeof (option_data));
+  memset (&option_data, 0, sizeof (option_data));
   option_data.c.set_id = htons (IPFIX_SOFTFLOWD_OPTION_TEMPLATE_ID);
   option_data.c.length = htons (sizeof (option_data));
   option_data.scope_pid = htonl ((u_int32_t) option->meteringProcessId);
@@ -809,7 +809,7 @@ send_ipfix_common (struct FLOW **flows, int num_flows,
 
   last_valid = num_packets = 0;
   for (j = 0; j < num_flows;) {
-    bzero (packet, sizeof (packet));
+    memset (packet, 0, sizeof (packet));
     if (version == 10) {
       ipfix = (struct IPFIX_HEADER *) packet;
       ipfix->version = htons (version);

--- a/netflow9.c
+++ b/netflow9.c
@@ -145,7 +145,7 @@ static int nf9_pkts_until_template = -1;
 
 static void
 nf9_init_template (void) {
-  bzero (&v4_template, sizeof (v4_template));
+  memset (&v4_template, 0, sizeof (v4_template));
   v4_template.h.c.flowset_id = htons (NFLOW9_TEMPLATE_SET_ID);
   v4_template.h.c.length = htons (sizeof (v4_template));
   v4_template.h.template_id = htons (NF9_SOFTFLOWD_V4_TEMPLATE_ID);
@@ -182,7 +182,7 @@ nf9_init_template (void) {
   v4_template.r[14].length = htons (2);
   v4_template.r[15].type = htons (NF9_SRC_VLAN);
   v4_template.r[15].length = htons (2);
-  bzero (&v6_template, sizeof (v6_template));
+  memset (&v6_template, 0, sizeof (v6_template));
   v6_template.h.c.flowset_id = htons (NFLOW9_TEMPLATE_SET_ID);
   v6_template.h.c.length = htons (sizeof (v6_template));
   v6_template.h.template_id = htons (NF9_SOFTFLOWD_V6_TEMPLATE_ID);
@@ -223,7 +223,7 @@ nf9_init_template (void) {
 
 static void
 nf9_init_option (u_int16_t ifidx, struct OPTION *option) {
-  bzero (&option_template, sizeof (option_template));
+  memset (&option_template, 0, sizeof (option_template));
   option_template.h.c.flowset_id = htons (NFLOW9_OPTION_TEMPLATE_SET_ID);
   option_template.h.c.length = htons (sizeof (option_template));
   option_template.h.template_id = htons (NF9_SOFTFLOWD_OPTION_TEMPLATE_ID);
@@ -238,7 +238,7 @@ nf9_init_option (u_int16_t ifidx, struct OPTION *option) {
   option_template.r[1].length =
     htons (sizeof (option_data.sampling_algorithm));
 
-  bzero (&option_data, sizeof (option_data));
+  memset (&option_data, 0, sizeof (option_data));
   option_data.c.flowset_id = htons (NF9_SOFTFLOWD_OPTION_TEMPLATE_ID);
   option_data.c.length = htons (sizeof (option_data));
   option_data.scope_ifidx = htonl (ifidx);
@@ -257,7 +257,7 @@ nf_flow_to_flowset (const struct FLOW *flow, u_char * packet, u_int len,
   struct NF9_SOFTFLOWD_DATA_COMMON *dc[2];
   u_int freclen, ret_len, nflows;
 
-  bzero (d, sizeof (d));
+  memset (d, 0, sizeof (d));
   *len_used = nflows = ret_len = 0;
   switch (flow->af) {
   case AF_INET:
@@ -363,7 +363,7 @@ send_netflow_v9 (struct SENDPARAMETER sp) {
 
   last_valid = num_packets = 0;
   for (j = 0; j < num_flows;) {
-    bzero (packet, sizeof (packet));
+    memset (packet, 0, sizeof (packet));
     nf9 = (struct NFLOW9_HEADER *) packet;
 
     nf9->version = htons (9);

--- a/psamp.c
+++ b/psamp.c
@@ -51,7 +51,7 @@ static int psamp_pkts_until_template = -1;
 static void
 psamp_init_template (struct PSAMP_SOFTFLOWD_TEMPLATE *template_p) {
   u_int index = 0;
-  bzero (template_p, sizeof (*template_p));
+  memset (template_p, 0, sizeof (*template_p));
   template_p->h.c.set_id = htons (IPFIX_TEMPLATE_SET_ID);
   template_p->h.c.length = htons (sizeof (struct PSAMP_SOFTFLOWD_TEMPLATE));
   template_p->h.r.template_id = htons (PSAMP_SOFTFLOWD_TEMPLATE_ID);


### PR DESCRIPTION
bzero is optionally unavailable with uClibc-ng.