### PR TITLE
Fix ipfix.c `vlanId` & `postVlanId` network byte order

### DIFF
--- a/ipfix.c
+++ b/ipfix.c
@@ -711,8 +711,8 @@ ipfix_flow_to_flowset (const struct FLOW *flow, u_char * packet,
     }
     if (param->track_level >= TRACK_FULL_VLAN) {
       dv[i] = (struct IPFIX_SOFTFLOWD_DATA_VLAN *) &packet[offset];
-      dv[i]->vlanId = flow->vlanid[i];
-      dv[i]->postVlanId = flow->vlanid[i ^ 1];
+      dv[i]->vlanId = htons (flow->vlanid[i]);
+      dv[i]->postVlanId = htons (flow->vlanid[i ^ 1]);
       offset += sizeof (struct IPFIX_SOFTFLOWD_DATA_VLAN);
     }
     if (param->track_level >= TRACK_FULL_VLAN_ETHER) {


### PR DESCRIPTION
IPFIX requires the vlanid to be in network byte order but it was
being exported in host byte order.