### PR TITLE
Correctly mask the 802.1q TCI bytes

### DIFF
--- a/softflowd.c
+++ b/softflowd.c
@@ -1233,6 +1233,11 @@ datalink_check (int linktype, const u_int8_t * pkt, u_int32_t caplen, int *af,
         *vlanid <<= 8;
         *vlanid |= pkt[j + dl->skiplen];
       }
+      /* 
+       * Mask out the PCP and DEI values,
+       * leaving just the VID.
+       */
+      *vlanid &= 0xFFF;
       vlan_size = 4;
     }
   }


### PR DESCRIPTION
Forgive the overly-verbose explanation of VLAN tag structure. I wanted to leave a detailed commit message for such a small change so future-me/maintainers would understand the importance of the mask.

The 802.1q tag is constructed as follows:
```
 0                   1                   2                   3
 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|             TPID              | PCP | |          VID          |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
                                       ^
                                       |
                                      DEI
                                \_______________________________/
                                               TCI
```

softflowd assumed that all 16 bits of the TCI represented the
VLAN ID (VID). If the PCP or DEI were not zero, the reported VLAN
ID would be incorrect (e.g. VLAN 4090 reported as 12282, not a valid
VID). The solution here is to apply a 12-bit mask to the extracted TCI
bytes.

This discards the PCP and DEI value, but softflowd wasn't reporting
those anyway. They could be recovered in the future if needed. For
terms and definitions without reading the IEEE 802.1q standard, the
Wikipedia article is excellent: https://en.wikipedia.org/wiki/IEEE_802.1Q