### PR TITLE
Report interfaceName in normal data and tempalte record

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,9 @@ AC_ARG_ENABLE(pthread,
 AC_ARG_ENABLE(ntopng,
               AC_HELP_STRING([--enable-ntopng], [enable flow sending to ntopng with zeromq (default NO)]),
               [ntopng=yes],[ntopng=no])
+AC_ARG_ENABLE(ifname,
+              AC_HELP_STRING([--enable-ifname], [enable flow reporting iface name in normal data of v9 (default NO)]),
+              [ifname=yes],[ifname=no])
 AC_ARG_ENABLE(flow-spray,
               AC_HELP_STRING([--enable-flow-spray],
                              [enable spray as flow tree type(default is RB)]),
@@ -140,6 +143,9 @@ if test "x$ntopng" = "xyes" ; then
   AC_SUBST([NTOPNG])
 fi
 AM_CONDITIONAL([ENABLE_NTOPNG], [test x$ntopng = xyes])
+if test "x$ifname" = "xyes" ; then
+  AC_DEFINE([ENABLE_IFNAME], 1, [enable reporting iface name])
+fi
 if test "x$ac_cv_type_uint8_t" = "xyes" ; then
 	AC_DEFINE([OUR_CFG_U_INT8_T], [uint8_t], [8-bit unsigned int])
 elif test "x$ac_cv_sizeof_char" = "x1" ; then

--- a/ipfix.c
+++ b/ipfix.c
@@ -47,7 +47,10 @@ const struct IPFIX_FIELD_SPECIFIER field_common[] = {
   {IPFIX_ingressInterface, 4},
   {IPFIX_egressInterface, 4},
   {IPFIX_flowDirection, 1},
-  {IPFIX_flowEndReason, 1}
+  {IPFIX_flowEndReason, 1},
+#ifdef ENABLE_IFNAME
+  {IPFIX_interfaceName, IFNAMSIZ}
+#endif
 };
 
 const struct IPFIX_FIELD_SPECIFIER field_transport[] = {
@@ -205,6 +208,9 @@ struct IPFIX_SOFTFLOWD_DATA_COMMON {
   u_int32_t octetDeltaCount, packetDeltaCount;
   u_int32_t ingressInterface, egressInterface;
   u_int8_t flowDirection, flowEndReason;
+#ifdef ENABLE_IFNAME
+  char interfaceName[IFNAMSIZ];
+#endif
 } __packed;
 
 struct IPFIX_SOFTFLOWD_DATA_TRANSPORT {
@@ -540,9 +546,9 @@ nflow9_init_option (u_int16_t ifidx, struct OPTION *option) {
   nf9opt_data.samplingAlgorithm = NFLOW9_SAMPLING_ALGORITHM_DETERMINISTIC;
   strncpy (nf9opt_data.interfaceName, option->interfaceName,
            strlen (option->interfaceName) <
-           strlen (nf9opt_data.interfaceName) ?
+           sizeof (nf9opt_data.interfaceName) ?
            strlen (option->interfaceName) :
-           strlen (nf9opt_data.interfaceName));
+           sizeof (nf9opt_data.interfaceName));
 }
 
 static void
@@ -580,9 +586,9 @@ ipfix_init_option (struct timeval *system_boot_time, struct OPTION *option) {
     htonl (option->sample > 0 ? option->sample - 1 : 0);
   strncpy (option_data.interfaceName, option->interfaceName,
            strlen (option->interfaceName) <
-           strlen (option_data.interfaceName) ?
+           sizeof (option_data.interfaceName) ?
            strlen (option->interfaceName) :
-           strlen (option_data.interfaceName));
+           sizeof (option_data.interfaceName));
 }
 
 static int
@@ -657,6 +663,7 @@ ipfix_flow_to_flowset (const struct FLOW *flow, u_char * packet,
   struct IPFIX_SOFTFLOWD_DATA_BICOMMON *dbc = NULL;
   struct IPFIX_SOFTFLOWD_DATA_BITRANSPORT *dbtr = NULL;
   struct IPFIX_SOFTFLOWD_DATA_BIICMP *dbi = NULL;
+  struct OPTION *option = &param->option;
 
   u_int freclen = 0, nflows = 0, offset = 0;
   u_int frecnum = bi_flag ? 1 : 2;
@@ -691,6 +698,13 @@ ipfix_flow_to_flowset (const struct FLOW *flow, u_char * packet,
     dc[i]->ingressInterface = dc[i]->egressInterface = htonl (ifidx);
     dc[i]->flowDirection = i;
     dc[i]->flowEndReason = flow->flowEndReason;
+#ifdef ENABLE_IFNAME
+    strncpy (dc[i]->interfaceName, option->interfaceName,
+             strlen (option->interfaceName) <
+             sizeof (dc[i]->interfaceName) ?
+             strlen (option->interfaceName) :
+             sizeof (dc[i]->interfaceName));
+#endif
     offset += sizeof (struct IPFIX_SOFTFLOWD_DATA_COMMON);
 
     if (flow->protocol != IPPROTO_ICMP && flow->protocol != IPPROTO_ICMPV6) {

--- a/softflowd.c
+++ b/softflowd.c
@@ -2016,8 +2016,10 @@ main (int argc, char **argv) {
       if (verbose_flag)
         fprintf (stderr, "Using %s (idx: %d)\n", dev, if_index);
       strncpy (flowtrack.param.option.interfaceName, dev,
-               strlen (dev) < strlen (flowtrack.param.option.interfaceName) ?
-               strlen (dev) : strlen (flowtrack.param.option.interfaceName));
+               strlen (dev) <
+               sizeof (flowtrack.param.option.interfaceName) ?
+               strlen (dev) :
+               sizeof (flowtrack.param.option.interfaceName));
       break;
     case 'r':
       if (capfile != NULL || dev != NULL) {
@@ -2030,9 +2032,9 @@ main (int argc, char **argv) {
       ctlsock_path = NULL;
       strncpy (flowtrack.param.option.interfaceName, capfile,
                strlen (capfile) <
-               strlen (flowtrack.param.option.interfaceName) ?
+               sizeof (flowtrack.param.option.interfaceName) ?
                strlen (capfile) :
-               strlen (flowtrack.param.option.interfaceName));
+               sizeof (flowtrack.param.option.interfaceName));
       break;
     case 't':
       /* Will exit on failure */
@@ -2279,8 +2281,9 @@ main (int argc, char **argv) {
   for (dest_idx = 0; dest_idx < target.num_destinations; dest_idx++) {
     dest = &target.destinations[dest_idx];
     if (dest->ss.ss_family != 0) {
-      logit (LOG_NOTICE, "Exporting flows to [%s]:%s", dest->hostname,
-             dest->servname);
+      logit (LOG_NOTICE, "Exporting flows from %s to [%s]:%s",
+             flowtrack.param.option.interfaceName,
+             dest->hostname, dest->servname);
     }
   }
   flowtrack.param.option.meteringProcessId = getpid ();


### PR DESCRIPTION
    Report interfaceName in normal data and template of v9 record

    Some popular netflow collectors like logstash and elasticsearch
    take if_name from common netflow records only.

    Add configure option --enable-ifname to report interfaceName
    in normal data and template of v9 record.

    Also fix if_name is empty string always since strlen(src_string) is 0 initially.
    Need to use sizeof() instead.