### PR TITLE
Add option for setting libpcap buffer size

### DIFF
--- a/softflowd.8
+++ b/softflowd.8
@@ -211,6 +211,8 @@ This implies the
 and
 .Fl 6
 flags and turns on additional debugging output.
+.It Fl B Ar size_bytes
+Libpcap buffer size in bytes
 .It Fl b
 Bidirectional mode in IPFIX (-b work with -v 10)
 .It Fl a


### PR DESCRIPTION
Some traffic can burst the default libpcap 2M buffer size. This PR adds an argument to set the buffer size in bytes.

A small rework had to be done to the pcap device open phase due to pcap_open_live returning an already activated pcap instance and pcap_set_buffer_size must be called to a non-active pcap instance.