### PR TITLE
Travis-ci:added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,13 @@ language: c
 os:
   - linux
   - osx
-
+arch:
+  - amd64
+  - ppc64le
+matrix:
+  exclude:
+   - os: osx
+     arch: ppc64le
 compiler: gcc
 sudo: false
 addons:


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch on behalf of IBM. The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/softflowd/builds/209291007 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!