### PR TITLE
Do not exit if pcap_activate() returns warning.

### DIFF
--- a/softflowd.c
+++ b/softflowd.c
@@ -1614,7 +1614,7 @@ setup_packet_capture (struct pcap **pcap, int *linktype,
       }
     if (pcap_lookupnet (dev, &bpf_net, &bpf_mask, ebuf) == -1)
       bpf_net = bpf_mask = 0;
-    if ((res = pcap_activate (*pcap)) != 0) {
+    if ((res = pcap_activate (*pcap)) < 0) {
       fprintf (stderr, "pcap_activate: %s\n", pcap_geterr (*pcap));
       exit (1);
     }


### PR DESCRIPTION
pcap_activate() can return 0 on success, negative value on error and positive value on partial success, e.g. PCAP_WARNING_PROMISC_NOTSUP when an interface doesn't support promisc mode. This can happen with some DLT_NULL interfaces.

When there was used pcap_open_live() it worked, but after switch to pcap_create+pcap_activate it fails now.

Also, libpcap uses this in pcap_open_live():

        status = pcap_activate(p);
        if (status < 0)
                goto fail;