### PR TITLE
Correct ethermac printing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+name: Build release packages
+
+on:
+  push:
+    tags:
+      - 'softflowd-*'
+
+jobs:
+  dist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libpcap-dev autoconf automake libtool
+      - name: make dist
+        run: |
+          autoreconf -if
+          ./configure
+          make dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-tarball
+          path: softflowd-*.tar.gz
+
+  rpm:
+    needs: dist
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-tarball
+      - name: Install build deps
+        run: |
+          dnf install -y rpm-build rpmdevtools libpcap-devel \
+            autoconf automake libtool gcc make
+      - name: Build RPM
+        run: |
+          rpmdev-setuptree
+          tar xzf softflowd-*.tar.gz --wildcards '*/softflowd.spec' \
+            '*/softflowd.init' '*/softflowd.sysconfig' --strip-components=1
+          cp softflowd-*.tar.gz ~/rpmbuild/SOURCES/
+          cp softflowd.init softflowd.sysconfig ~/rpmbuild/SOURCES/
+          cp softflowd.spec ~/rpmbuild/SPECS/
+          rpmbuild -ba ~/rpmbuild/SPECS/softflowd.spec
+          find ~/rpmbuild/RPMS ~/rpmbuild/SRPMS -name '*.rpm' -exec cp {} . \;
+      - uses: actions/upload-artifact@v4
+        with:
+          name: rpm-packages
+          path: '*.rpm'
+
+  release:
+    needs: rpm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: rpm-packages
+          path: rpm-packages
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: rpm-packages/*.rpm

--- a/Makefile.am
+++ b/Makefile.am
@@ -15,3 +15,4 @@ softflowd_LDADD = $(LEGACY) $(NTOPNG)
 softflowd_DEPENDENCIES = $(LEGACY) $(NTOPNG)
 softflowctl_SOURCES = softflowctl.c $(COMMON)
 dist_man_MANS = softflowd.8 softflowctl.8
+EXTRA_DIST = softflowd.spec softflowd.init softflowd.sysconfig

--- a/softflowd.c
+++ b/softflowd.c
@@ -371,14 +371,8 @@ format_time (time_t t) {
 
 }
 
-static const char *
-format_ethermac (uint8_t ethermac[6]) {
-  static char buf[1024];
-  snprintf (buf, sizeof (buf), "%.2x:%.2x:%.2x:%.2x:%.2x:%.2x",
-            ethermac[0], ethermac[1], ethermac[2], ethermac[3],
-            ethermac[4], ethermac[5]);
-  return buf;
-}
+#define PRI_ETHERMAC "%.2x:%.2x:%.2x:%.2x:%.2x:%.2x"
+#define FORMAT_ETHERMAC(em) em[0], em[1], em[2], em[3], em[4], em[5]
 
 /* Format a flow in a verbose and ugly way */
 static const char *
@@ -399,7 +393,7 @@ format_flow (struct FLOW *flow) {
             "octets>:%u packets>:%u octets<:%u packets<:%u "
             "start:%s.%03lld finish:%s.%03lld tcp>:%02x tcp<:%02x "
             "flowlabel>:%08x flowlabel<:%08x "
-            "vlan>:%u vlan<:%u ether:%s <> %s", flow->flow_seq, addr1,
+            "vlan>:%u vlan<:%u ether:" PRI_ETHERMAC " <> " PRI_ETHERMAC, flow->flow_seq, addr1,
             ntohs (flow->port[0]), addr2, ntohs (flow->port[1]),
             (int) flow->protocol, flow->octets[0], flow->packets[0],
             flow->octets[1], flow->packets[1], start_time,
@@ -407,8 +401,8 @@ format_flow (struct FLOW *flow) {
             (long long) ((flow->flow_last.tv_usec + 500) / 1000),
             flow->tcp_flags[0], flow->tcp_flags[1], flow->ip6_flowlabel[0],
             flow->ip6_flowlabel[1], flow->vlanid[0], flow->vlanid[1],
-            format_ethermac (flow->ethermac[0]),
-            format_ethermac (flow->ethermac[1]));
+            FORMAT_ETHERMAC (flow->ethermac[0]),
+            FORMAT_ETHERMAC (flow->ethermac[1]));
 
   return (buf);
 }
@@ -424,15 +418,18 @@ format_flow_brief (struct FLOW *flow) {
 
   snprintf (buf, sizeof (buf),
             "seq:%" PRIu64 " [%s]:%hu <> [%s]:%hu proto:%u "
-            "vlan>:%u vlan<:%u  ether:%s <> %s ",
+            "vlan>:%u vlan<:%u  ether:" PRI_ETHERMAC " <> " PRI_ETHERMAC " ",
             flow->flow_seq,
             addr1, ntohs (flow->port[0]), addr2, ntohs (flow->port[1]),
             (int) flow->protocol, flow->vlanid[0], flow->vlanid[1],
-            format_ethermac (flow->ethermac[0]),
-            format_ethermac (flow->ethermac[1]));
+            FORMAT_ETHERMAC (flow->ethermac[0]),
+            FORMAT_ETHERMAC (flow->ethermac[1]));
 
   return (buf);
 }
+
+#undef PRI_ETHERMAC
+#undef FORMAT_ETHERMAC
 
 /* Fill in transport-layer (tcp/udp) portions of flow record */
 static void

--- a/softflowd.spec
+++ b/softflowd.spec
@@ -3,7 +3,7 @@
 
 Name: softflowd
 Summary: Network traffic analyser capable of Cisco NetFlow data export
-Version: 1.1.0
+Version: 1.1.1
 Release: 1.%{_RHTAG}
 Source: softflowd-%{version}.tar.gz
 Group: System/Utilities
@@ -23,6 +23,7 @@ versions 1, 5 or 9 of the NetFlow protocol.
 
 %prep
 %setup
+autoreconf -if
 
 %build
 %configure


### PR DESCRIPTION
`format_ethermac` wrote to a static buffer and then returned the address of that buffer. This meant that multiple uses of it within a single `snprintf` wrote the same value (last argument evaluated) despite different inputs.

Because of this, `dump-flows` (and the verbose debug printing) always displayed the destination ether address as both the source and destination.

Refactored to use macros to inline the formatting within the outer `snprintf` call, removing the intermediary buffer completely.

Tested on RHEL 9 with `softflowd` monitoring a bridge interface, `dump-flows` now prints the correct source and destination ether addresses.